### PR TITLE
Hide dropdown when secondary target on blur is not dropdown item

### DIFF
--- a/src/components/nav/Nav.js
+++ b/src/components/nav/Nav.js
@@ -9,6 +9,12 @@ export default function Nav() {
   function handleClick(e) {
     setDrop(prevState => !prevState)
   }
+
+  function handleBlur(e) {
+      if (e?.relatedTarget?.className !== 'nav--dropdown--a') {
+          setDrop(false)
+      }
+  }
       
     return (
             <nav role='navigation'>
@@ -36,7 +42,9 @@ export default function Nav() {
                         </button>  
                     </div>
 
-                    <div className='portfolio' >
+                    <div className='portfolio'
+                        onBlur={handleBlur}
+                    >
 
                         <button 
                             id='nav--portfolio--button' 


### PR DESCRIPTION
Eventet som kommer inn fra `onBlur` er et `FocusEvent`, som inneholder informasjon om "secondary target". For `blur` events er secondary target det elementet som får fokus. Så hvis vi legger til en `if` statement som sjekker om elementet som får fokus (det du trykker på/secondary target) ikke er et element i dropdownen, kan vi skjule dropdown. Hvis elementet som får fokus er et element i dropdown, gjør ikke `handleBlur` noe.

Denne tabellen dokumenterer hva `FocusEvent.relatedTarget` er for ulike typer `FocusEvent`: https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent/relatedTarget